### PR TITLE
fix: clear stale printData when submitting new config from HomePage

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -46,3 +46,11 @@ export function loadPrintData(): PrintData | null {
 export function savePrintData(data: PrintData): void {
 	write(PRINT_KEY, data);
 }
+
+export function clearPrintData(): void {
+	try {
+		sessionStorage.removeItem(PRINT_KEY);
+	} catch (e) {
+		console.error(`sessionStorage remove failed for ${PRINT_KEY}`, e);
+	}
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -17,13 +17,14 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/Select";
-import { saveFormConfig } from "@/lib/storage";
+import { clearPrintData, saveFormConfig } from "@/lib/storage";
 import formSchema, { type FormConfig } from "@/schemas/FormSchema";
 
 const HomePage = () => {
 	const navigate = useNavigate();
 
 	const onSubmit = (data: FormConfig) => {
+		clearPrintData();
 		saveFormConfig(data);
 		navigate("/newform");
 	};

--- a/src/pages/NewFormPage.tsx
+++ b/src/pages/NewFormPage.tsx
@@ -12,12 +12,15 @@ const NewFormPage = () => {
 	const navigate = useNavigate();
 
 	const formConfig = useMemo(loadFormConfig, []);
-	const existingPrintData = useMemo(loadPrintData, []);
-
 	const rowCount = formConfig ? formConfig.maxNum - formConfig.minNum + 1 : 0;
+	const existingPrintData = useMemo(() => {
+		const data = loadPrintData();
+		return data && data.table.length === rowCount ? data : null;
+	}, [rowCount]);
 
 	const [values, setValues] = useState<Cell[][]>(
-		existingPrintData?.table ??
+		() =>
+			existingPrintData?.table ??
 			Array.from({ length: rowCount }, () => Array(ROW_LENGTH).fill("")),
 	);
 	const [project, setProject] = useState(existingPrintData?.project ?? "");


### PR DESCRIPTION
Bug: submitting a fresh form config on HomePage (e.g. 1-20 → back to home → 1-10) left the previous printData in sessionStorage, so NewFormPage rendered the old table length with stale cell values.

Fix is two-layered:

1. HomePage.onSubmit now calls clearPrintData() before saving the new config. Expresses intent: "submit from home = start fresh."

2. NewFormPage defensively validates that existingPrintData.table length matches the current config's rowCount; mismatched data is treated as absent (table + project + date + pile all reset). This closes the invariant at the consumer so any future producer path can't silently reintroduce the bug.

Preserve paths unchanged:
- Edit from /print → /newform keeps data (same rowCount)
- /copy → /newform keeps data (same rowCount)
- Refresh on /newform keeps data (same rowCount)

Verified end-to-end with Playwright against the 20→10 scenario.