### PR TITLE
feat(ui): Apple-style design system rollout

### DIFF
--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -6,34 +6,23 @@ interface PageTitleProps {
 
 const PageTitle: React.FC<PageTitleProps> = ({ summary = true }) => {
 	return (
-		<header className="mb-6">
-			<div className="border-b-4 border-double border-seal pb-3 text-center">
-				<div className="font-[var(--font-serif-cn)] text-3xl tracking-[0.35em] text-seal">
-					富財貿易打樁工程
-				</div>
-				<div className="mt-1 font-serif text-base tracking-[0.18em] text-ink uppercase">
-					Fook Choy Trading &amp; Piling Engineering
-				</div>
-				<div className="mt-2 text-[11px] font-serif text-ink/70 leading-relaxed">
-					474, Jalan Nuri Indah 9, Taman Thivy Jaya, 70100 Seremban, N.S.D.K
-					&nbsp;·&nbsp; Co.No. 000805830-K
-				</div>
-				<div className="text-[11px] font-serif text-ink/70 flex justify-center gap-6 mt-0.5">
-					<span>
-						<span className="font-semibold">Tel</span>&nbsp;012-6367702
-					</span>
-					<span>
-						<span className="font-semibold">Email</span>
-						&nbsp;fookchoy327@yahoo.com.my
-					</span>
-				</div>
-			</div>
+		<header className="mb-8 text-center">
+			<h1 className="text-2xl font-semibold text-ink">富財貿易打樁工程</h1>
+			<p className="mt-1 text-sm font-medium text-ink-soft tracking-wide">
+				Fook Choy Trading &amp; Piling Engineering
+			</p>
+			<p className="mt-3 text-xs text-ink-soft">
+				474, Jalan Nuri Indah 9, Taman Thivy Jaya, 70100 Seremban, N.S.D.K
+				&nbsp;·&nbsp; Co.No. 000805830-K
+			</p>
+			<p className="text-xs text-ink-soft flex justify-center gap-5 mt-1">
+				<span>Tel&nbsp;012-6367702</span>
+				<span>fookchoy327@yahoo.com.my</span>
+			</p>
 			{summary && (
-				<div className="mt-3 text-center">
-					<span className="inline-block px-4 py-1 font-serif text-base tracking-[0.3em] text-seal">
-						【 PILING RECORD SUMMARY 】
-					</span>
-				</div>
+				<p className="mt-4 text-sm font-medium text-ink">
+					Piling Record Summary
+				</p>
 			)}
 		</header>
 	);

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -6,31 +6,36 @@ interface PageTitleProps {
 
 const PageTitle: React.FC<PageTitleProps> = ({ summary = true }) => {
 	return (
-		<div className="border-b border-gray-200 pb-3 mb-4">
-			<div className="text-xl font-bold text-gray-800">富財貿易打樁工程</div>
-			<div className="text-lg font-bold text-gray-700">
-				FOOK CHOY TRADING & PILING ENGINEERING
-			</div>
-			<div className="text-xs mt-1 text-gray-500">
-				474, Jalan Nuri Indah 9, Taman Thivy Jaya, 70100 Seremban, N.S.D.K
-			</div>
-			<div className="text-xs text-gray-500">(Co.No. 000805830-K)</div>
-			<div className="text-xs flex space-x-5 justify-center items-center text-gray-500">
-				<div>
-					<span className="font-bold">Tel: </span>
-					<span>012-6367702</span>
+		<header className="mb-6">
+			<div className="border-b-4 border-double border-seal pb-3 text-center">
+				<div className="font-[var(--font-serif-cn)] text-3xl tracking-[0.35em] text-seal">
+					富財貿易打樁工程
 				</div>
-				<div>
-					<span className="font-bold">Email: </span>
-					<span>fookchoy327@yahoo.com.my</span>
+				<div className="mt-1 font-serif text-base tracking-[0.18em] text-ink uppercase">
+					Fook Choy Trading &amp; Piling Engineering
+				</div>
+				<div className="mt-2 text-[11px] font-serif text-ink/70 leading-relaxed">
+					474, Jalan Nuri Indah 9, Taman Thivy Jaya, 70100 Seremban, N.S.D.K
+					&nbsp;·&nbsp; Co.No. 000805830-K
+				</div>
+				<div className="text-[11px] font-serif text-ink/70 flex justify-center gap-6 mt-0.5">
+					<span>
+						<span className="font-semibold">Tel</span>&nbsp;012-6367702
+					</span>
+					<span>
+						<span className="font-semibold">Email</span>
+						&nbsp;fookchoy327@yahoo.com.my
+					</span>
 				</div>
 			</div>
 			{summary && (
-				<div className="text-base font-bold mt-2 text-gray-800">
-					PILING RECORD SUMMARY
+				<div className="mt-3 text-center">
+					<span className="inline-block px-4 py-1 font-serif text-base tracking-[0.3em] text-seal">
+						【 PILING RECORD SUMMARY 】
+					</span>
 				</div>
 			)}
-		</div>
+		</header>
 	);
 };
 

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -9,11 +9,11 @@ describe("Button", () => {
 		expect(btn.tagName).toBe("BUTTON");
 	});
 
-	it("applies the default seal (crimson) variant when no variant set", () => {
+	it("applies the default primary variant when no variant set", () => {
 		render(<Button>OK</Button>);
 		const btn = screen.getByRole("button", { name: "OK" });
 		expect(btn.className).toMatch(/bg-seal/);
-		expect(btn.className).toMatch(/text-paper/);
+		expect(btn.className).toMatch(/text-white/);
 	});
 
 	it("applies the ghost-outline variant", () => {
@@ -23,11 +23,11 @@ describe("Button", () => {
 		expect(btn.className).not.toMatch(/bg-seal\b/);
 	});
 
-	it("applies the seal stamp variant", () => {
+	it("applies the seal outline variant", () => {
 		render(<Button variant="seal">Stamp</Button>);
 		const btn = screen.getByRole("button", { name: "Stamp" });
-		expect(btn.className).toMatch(/border-2/);
 		expect(btn.className).toMatch(/border-seal/);
+		expect(btn.className).toMatch(/text-seal/);
 	});
 
 	it("applies the xl size", () => {
@@ -76,9 +76,9 @@ describe("Button", () => {
 		expect(refHolder.current).toBeInstanceOf(HTMLButtonElement);
 	});
 
-	it("uses serif font", () => {
+	it("uses a pill (rounded-full) shape", () => {
 		render(<Button>Hi</Button>);
 		const btn = screen.getByRole("button", { name: "Hi" });
-		expect(btn.className).toMatch(/font-serif/);
+		expect(btn.className).toMatch(/rounded-full/);
 	});
 });

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -9,17 +9,25 @@ describe("Button", () => {
 		expect(btn.tagName).toBe("BUTTON");
 	});
 
-	it("applies the default amber variant when no variant set", () => {
+	it("applies the default seal (crimson) variant when no variant set", () => {
 		render(<Button>OK</Button>);
 		const btn = screen.getByRole("button", { name: "OK" });
-		expect(btn.className).toMatch(/bg-amber-400/);
+		expect(btn.className).toMatch(/bg-seal/);
+		expect(btn.className).toMatch(/text-paper/);
 	});
 
 	it("applies the ghost-outline variant", () => {
 		render(<Button variant="ghost-outline">Cancel</Button>);
 		const btn = screen.getByRole("button", { name: "Cancel" });
-		expect(btn.className).toMatch(/border-gray-300/);
-		expect(btn.className).not.toMatch(/bg-amber-400/);
+		expect(btn.className).toMatch(/border-rule/);
+		expect(btn.className).not.toMatch(/bg-seal\b/);
+	});
+
+	it("applies the seal stamp variant", () => {
+		render(<Button variant="seal">Stamp</Button>);
+		const btn = screen.getByRole("button", { name: "Stamp" });
+		expect(btn.className).toMatch(/border-2/);
+		expect(btn.className).toMatch(/border-seal/);
 	});
 
 	it("applies the xl size", () => {
@@ -33,7 +41,7 @@ describe("Button", () => {
 		render(<Button className="custom-x">Hi</Button>);
 		const btn = screen.getByRole("button", { name: "Hi" });
 		expect(btn.className).toMatch(/custom-x/);
-		expect(btn.className).toMatch(/bg-amber-400/);
+		expect(btn.className).toMatch(/bg-seal/);
 	});
 
 	it("renders as the child element when asChild is true", () => {
@@ -44,14 +52,14 @@ describe("Button", () => {
 		);
 		const link = screen.getByRole("link", { name: "Link" });
 		expect(link.tagName).toBe("A");
-		expect(link.className).toMatch(/bg-amber-400/);
+		expect(link.className).toMatch(/bg-seal/);
 	});
 
 	it("respects disabled prop", () => {
 		render(<Button disabled>Off</Button>);
 		const btn = screen.getByRole("button", { name: "Off" });
 		expect(btn).toBeDisabled();
-		expect(btn.className).toMatch(/disabled:cursor-not-allowed/);
+		expect(btn.className).toMatch(/disabled:pointer-events-none/);
 	});
 
 	it("forwards ref to the underlying element", () => {
@@ -66,5 +74,11 @@ describe("Button", () => {
 			</Button>,
 		);
 		expect(refHolder.current).toBeInstanceOf(HTMLButtonElement);
+	});
+
+	it("uses serif font", () => {
+		render(<Button>Hi</Button>);
+		const btn = screen.getByRole("button", { name: "Hi" });
+		expect(btn.className).toMatch(/font-serif/);
 	});
 });

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -5,29 +5,28 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center whitespace-nowrap rounded-sm font-serif text-sm tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-seal focus-visible:ring-offset-2 focus-visible:ring-offset-paper disabled:pointer-events-none disabled:opacity-50",
+	"inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-seal focus-visible:ring-offset-2 focus-visible:ring-offset-paper disabled:pointer-events-none disabled:opacity-50",
 	{
 		variants: {
 			variant: {
-				default:
-					"bg-seal text-paper shadow-sm hover:bg-seal-hover hover:shadow-md active:translate-y-px",
+				default: "bg-seal text-white hover:bg-seal-hover active:scale-[0.98]",
 				destructive:
 					"bg-destructive text-destructive-foreground hover:bg-destructive/90",
 				outline:
-					"border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+					"border border-rule bg-surface text-ink hover:bg-paper-strong active:scale-[0.98]",
 				secondary:
-					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
-				ghost: "hover:bg-accent hover:text-accent-foreground",
+					"bg-paper-strong text-ink hover:bg-rule-soft active:scale-[0.98]",
+				ghost: "text-ink hover:bg-paper-strong",
 				"ghost-outline":
-					"border border-rule text-ink bg-surface hover:bg-paper-strong active:translate-y-px focus-visible:ring-rule",
-				seal: "bg-surface text-seal border-2 border-seal shadow-sm hover:bg-seal hover:text-surface active:translate-y-px",
-				link: "text-primary underline-offset-4 hover:underline",
+					"border border-rule bg-surface text-ink hover:bg-paper-strong active:scale-[0.98]",
+				seal: "bg-surface text-seal border border-seal hover:bg-seal hover:text-white active:scale-[0.98]",
+				link: "text-seal underline-offset-4 hover:underline",
 			},
 			size: {
-				default: "h-10 px-4 py-2",
-				sm: "h-9 rounded-sm px-3",
-				lg: "h-11 rounded-sm px-8",
-				xl: "h-12 rounded-sm px-10 text-base font-semibold",
+				default: "h-10 px-5",
+				sm: "h-8 px-4 text-xs",
+				lg: "h-11 px-6",
+				xl: "h-12 px-8 text-base",
 				icon: "h-10 w-10",
 			},
 		},

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -5,12 +5,12 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed",
+	"inline-flex items-center justify-center whitespace-nowrap rounded-sm font-serif text-sm tracking-wide transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-seal focus-visible:ring-offset-2 focus-visible:ring-offset-paper disabled:pointer-events-none disabled:opacity-50",
 	{
 		variants: {
 			variant: {
 				default:
-					"bg-amber-400 text-gray-900 shadow-sm hover:bg-amber-500 hover:shadow-md active:translate-y-px",
+					"bg-seal text-paper shadow-sm hover:bg-seal-hover hover:shadow-md active:translate-y-px",
 				destructive:
 					"bg-destructive text-destructive-foreground hover:bg-destructive/90",
 				outline:
@@ -19,14 +19,15 @@ const buttonVariants = cva(
 					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground",
 				"ghost-outline":
-					"border border-gray-300 text-gray-700 bg-white hover:bg-gray-100 active:translate-y-px",
+					"border border-rule text-ink bg-paper hover:bg-paper-strong active:translate-y-px focus-visible:ring-rule",
+				seal: "bg-paper text-seal border-2 border-seal shadow-sm hover:bg-seal hover:text-paper active:translate-y-px",
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {
 				default: "h-10 px-4 py-2",
-				sm: "h-9 rounded-md px-3",
-				lg: "h-11 rounded-md px-8",
-				xl: "h-12 rounded-md px-8 text-base font-semibold",
+				sm: "h-9 rounded-sm px-3",
+				lg: "h-11 rounded-sm px-8",
+				xl: "h-12 rounded-sm px-10 text-base font-semibold",
 				icon: "h-10 w-10",
 			},
 		},

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -19,8 +19,8 @@ const buttonVariants = cva(
 					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground",
 				"ghost-outline":
-					"border border-rule text-ink bg-paper hover:bg-paper-strong active:translate-y-px focus-visible:ring-rule",
-				seal: "bg-paper text-seal border-2 border-seal shadow-sm hover:bg-seal hover:text-paper active:translate-y-px",
+					"border border-rule text-ink bg-surface hover:bg-paper-strong active:translate-y-px focus-visible:ring-rule",
+				seal: "bg-surface text-seal border-2 border-seal shadow-sm hover:bg-seal hover:text-surface active:translate-y-px",
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {

--- a/src/index.css
+++ b/src/index.css
@@ -25,15 +25,17 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 
-	/* Classic letterhead palette */
-	--color-paper: #faf6ef;
-	--color-paper-strong: #f4ecdb;
-	--color-ink: #1a1a1a;
-	--color-seal: #8b1a1a;
-	--color-seal-hover: #6b1313;
-	--color-seal-soft: #b94747;
-	--color-rule: #c8b89a;
-	--color-rule-soft: #e6ddc7;
+	/* Classic tea-brown (茶色) vintage palette */
+	--color-paper: #f5ecd9;
+	--color-paper-strong: #ede0c4;
+	--color-ink: #3a2a1c;
+	--color-seal: #6b4226;
+	--color-seal-hover: #4a2d18;
+	--color-seal-soft: #8a5a38;
+	--color-rule: #c4a878;
+	--color-rule-soft: #ddc8a0;
+	--color-gold: #b8862a;
+	--color-gold-soft: #d4a44a;
 
 	/* Serif stacks */
 	--font-serif-cn:

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,22 @@
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
+
+	/* Classic letterhead palette */
+	--color-paper: #faf6ef;
+	--color-paper-strong: #f4ecdb;
+	--color-ink: #1a1a1a;
+	--color-seal: #8b1a1a;
+	--color-seal-hover: #6b1313;
+	--color-seal-soft: #b94747;
+	--color-rule: #c8b89a;
+	--color-rule-soft: #e6ddc7;
+
+	/* Serif stacks */
+	--font-serif-cn:
+		"Noto Serif SC", "Songti SC", "STSong", "Source Han Serif SC", Georgia,
+		"Times New Roman", serif;
+	--font-serif: Georgia, "Times New Roman", "Noto Serif SC", serif;
 }
 
 :root {
@@ -63,6 +79,14 @@ body {
 	margin: 0;
 	min-width: 320px;
 	min-height: 100vh;
+	background-color: var(--color-paper);
+	color: var(--color-ink);
+}
+
+@media print {
+	body {
+		background-color: #ffffff;
+	}
 }
 
 * {

--- a/src/index.css
+++ b/src/index.css
@@ -26,13 +26,16 @@
 	--radius-lg: var(--radius);
 
 	/* Classic tea-brown (茶色) vintage palette */
-	--color-paper: #f5ecd9;
-	--color-paper-strong: #ede0c4;
+	--color-paper: #f5ecd9; /* body bg (cream / aged paper) */
+	--color-paper-strong: #ede0c4; /* subtle band, table stripe */
+	--color-surface: #fdfaf3; /* near-white card/input bg, lifts off paper */
+	--color-surface-soft: #f9f3e4;
 	--color-ink: #3a2a1c;
 	--color-seal: #6b4226;
 	--color-seal-hover: #4a2d18;
 	--color-seal-soft: #8a5a38;
 	--color-rule: #c4a878;
+	--color-rule-strong: #a98558; /* darker rule for active borders */
 	--color-rule-soft: #ddc8a0;
 	--color-gold: #b8862a;
 	--color-gold-soft: #d4a44a;

--- a/src/index.css
+++ b/src/index.css
@@ -25,26 +25,26 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 
-	/* Classic tea-brown (茶色) vintage palette */
-	--color-paper: #f5ecd9; /* body bg (cream / aged paper) */
-	--color-paper-strong: #ede0c4; /* subtle band, table stripe */
-	--color-surface: #fdfaf3; /* near-white card/input bg, lifts off paper */
-	--color-surface-soft: #f9f3e4;
-	--color-ink: #3a2a1c;
-	--color-seal: #6b4226;
-	--color-seal-hover: #4a2d18;
-	--color-seal-soft: #8a5a38;
-	--color-rule: #c4a878;
-	--color-rule-strong: #a98558; /* darker rule for active borders */
-	--color-rule-soft: #ddc8a0;
-	--color-gold: #b8862a;
-	--color-gold-soft: #d4a44a;
+	/* Apple-style monochrome minimal palette */
+	--color-paper: #f5f5f7; /* body bg */
+	--color-paper-strong: #ebebed; /* subtle band */
+	--color-surface: #ffffff; /* card / input bg */
+	--color-surface-soft: #fafafa;
+	--color-ink: #1d1d1f; /* near-black, primary text + primary action */
+	--color-ink-soft: #6e6e73; /* secondary text */
+	--color-seal: #1d1d1f; /* primary action = ink (intentionally no brand color) */
+	--color-seal-hover: #000000;
+	--color-seal-soft: #424245;
+	--color-rule: #d2d2d7;
+	--color-rule-strong: #86868b;
+	--color-rule-soft: #e8e8ed;
+	--color-gold: #1d1d1f; /* legacy alias */
+	--color-gold-soft: #424245;
 
-	/* Serif stacks */
-	--font-serif-cn:
-		"Noto Serif SC", "Songti SC", "STSong", "Source Han Serif SC", Georgia,
-		"Times New Roman", serif;
-	--font-serif: Georgia, "Times New Roman", "Noto Serif SC", serif;
+	/* Font stacks */
+	--font-system:
+		-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto,
+		"PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
 :root {
@@ -69,11 +69,11 @@
 	--ring: 222.2 84% 4.9%;
 	--radius: 0.5rem;
 
-	font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+	font-family: var(--font-system);
 	line-height: 1.5;
 	font-weight: 400;
-	color: hsl(var(--foreground));
-	background-color: hsl(var(--background));
+	color: var(--color-ink);
+	background-color: var(--color-paper);
 	font-synthesis: none;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;

--- a/src/pages/CopyPage.test.tsx
+++ b/src/pages/CopyPage.test.tsx
@@ -59,7 +59,7 @@ describe("CopyPage", () => {
 		seedStorage();
 		renderPage();
 		const user = userEvent.setup();
-		await user.click(screen.getByRole("button", { name: /OK/i }));
+		await user.click(screen.getByRole("button", { name: "确认" }));
 		expect(navigateMock).toHaveBeenCalledWith("/newform");
 	});
 
@@ -75,7 +75,7 @@ describe("CopyPage", () => {
 		await user.type(firstInput, "5");
 		await user.type(lastInput, "3");
 		await user.type(valueInput, "1");
-		await user.click(screen.getByRole("button", { name: /OK/i }));
+		await user.click(screen.getByRole("button", { name: "确认" }));
 
 		expect(screen.getByTestId("error-sixM")).toHaveTextContent(
 			"第二个号码少过5",
@@ -95,7 +95,7 @@ describe("CopyPage", () => {
 		await user.type(firstInput, "5");
 		await user.type(lastInput, "3");
 		await user.type(valueInput, "1");
-		await user.click(screen.getByRole("button", { name: /OK/i }));
+		await user.click(screen.getByRole("button", { name: "确认" }));
 		expect(screen.getByTestId("error-sixM")).toBeInTheDocument();
 
 		await user.clear(lastInput);
@@ -111,7 +111,7 @@ describe("CopyPage", () => {
 		await user.type(screen.getByLabelText("3 METER first pile"), "1");
 		await user.type(screen.getByLabelText("3 METER last pile"), "11");
 		await user.type(screen.getByLabelText("3 METER value"), "5");
-		await user.click(screen.getByRole("button", { name: /OK/i }));
+		await user.click(screen.getByRole("button", { name: "确认" }));
 
 		expect(screen.getByTestId("error-threeM")).toHaveTextContent(
 			"第二个号码不能大于10",

--- a/src/pages/CopyPage.tsx
+++ b/src/pages/CopyPage.tsx
@@ -62,7 +62,7 @@ type RangeState = { first: string; last: string; value: string };
 const emptyRange: RangeState = { first: "", last: "", value: "" };
 
 const inputClass =
-	"bg-paper border border-rule rounded-sm px-3 py-2 w-[120px] font-serif tabular-nums text-center text-base focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+	"bg-surface border border-rule rounded-sm px-3 py-2 w-[120px] font-serif tabular-nums text-center text-base focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 const CopyPage = () => {
 	const navigate = useNavigate();
@@ -162,7 +162,7 @@ const CopyPage = () => {
 		<div className="max-w-2xl mx-auto px-4 py-6">
 			<PageTitle summary={false} />
 
-			<div className="border-2 border-double border-seal rounded-sm bg-paper shadow-sm">
+			<div className="border-2 border-double border-seal rounded-sm bg-surface shadow-md">
 				<div className="border-b border-rule-soft px-6 py-3 text-center font-serif text-sm tracking-[0.3em] text-seal uppercase">
 					【 复制数据 / Copy Range 】
 				</div>

--- a/src/pages/CopyPage.tsx
+++ b/src/pages/CopyPage.tsx
@@ -62,7 +62,7 @@ type RangeState = { first: string; last: string; value: string };
 const emptyRange: RangeState = { first: "", last: "", value: "" };
 
 const inputClass =
-	"bg-surface border border-rule rounded-sm px-3 py-2 w-[120px] font-serif tabular-nums text-center text-base focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+	"bg-surface border border-rule rounded-xl h-11 px-3 w-[110px] tabular-nums text-center focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 const CopyPage = () => {
 	const navigate = useNavigate();
@@ -162,95 +162,85 @@ const CopyPage = () => {
 		<div className="max-w-2xl mx-auto px-4 py-6">
 			<PageTitle summary={false} />
 
-			<div className="border-2 border-double border-seal rounded-sm bg-surface shadow-md">
-				<div className="border-b border-rule-soft px-6 py-3 text-center font-serif text-sm tracking-[0.3em] text-seal uppercase">
-					【 复制数据 / Copy Range 】
-				</div>
+			<div className="bg-surface border border-rule rounded-2xl shadow-sm overflow-hidden">
+				{RANGES.map((cfg, index) => {
+					const isDecimal = cfg.key === "pen";
+					const state = ranges[cfg.key];
+					const error = errors[cfg.key];
+					const errorId = `error-${cfg.key}`;
+					const onValue = (v: string) =>
+						isDecimal
+							? handleDecimalChange(v, cfg.key, "value")
+							: handleIntegerChange(v, cfg.key, "value");
 
-				<div className="divide-y divide-rule-soft">
-					{RANGES.map((cfg) => {
-						const isDecimal = cfg.key === "pen";
-						const state = ranges[cfg.key];
-						const error = errors[cfg.key];
-						const errorId = `error-${cfg.key}`;
-						const onValue = (v: string) =>
-							isDecimal
-								? handleDecimalChange(v, cfg.key, "value")
-								: handleIntegerChange(v, cfg.key, "value");
+					return (
+						<section
+							key={cfg.key}
+							className={`px-6 py-5 ${index > 0 ? "border-t border-rule-soft" : ""}`}
+						>
+							<h3 className="text-sm font-semibold text-ink-soft tracking-wide mb-3">
+								{cfg.label}
+							</h3>
 
-						return (
-							<section key={cfg.key} className="px-6 py-5">
-								<div className="flex items-baseline justify-between mb-3">
-									<h3 className="font-serif text-base font-semibold tracking-[0.2em] text-seal uppercase">
-										{cfg.label}
-									</h3>
-									<span className="font-serif text-xs tracking-widest text-ink/60 uppercase">
-										Range
-									</span>
+							<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+								<div className="flex items-center gap-2">
+									<input
+										type="number"
+										aria-label={`${cfg.label} first pile`}
+										aria-invalid={!!error}
+										aria-describedby={error ? errorId : undefined}
+										className={inputClass}
+										value={state.first}
+										onChange={(e) =>
+											handleIntegerChange(e.target.value, cfg.key, "first")
+										}
+									/>
+									<span className="text-ink-soft">—</span>
+									<input
+										type="number"
+										aria-label={`${cfg.label} last pile`}
+										aria-invalid={!!error}
+										aria-describedby={error ? errorId : undefined}
+										className={inputClass}
+										value={state.last}
+										onChange={(e) =>
+											handleIntegerChange(e.target.value, cfg.key, "last")
+										}
+									/>
 								</div>
 
-								<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
-									<div className="flex items-center gap-2">
-										<input
-											type="number"
-											aria-label={`${cfg.label} first pile`}
-											aria-invalid={!!error}
-											aria-describedby={error ? errorId : undefined}
-											className={inputClass}
-											value={state.first}
-											onChange={(e) =>
-												handleIntegerChange(e.target.value, cfg.key, "first")
-											}
-										/>
-										<span className="text-rule font-serif text-xl">—</span>
-										<input
-											type="number"
-											aria-label={`${cfg.label} last pile`}
-											aria-invalid={!!error}
-											aria-describedby={error ? errorId : undefined}
-											className={inputClass}
-											value={state.last}
-											onChange={(e) =>
-												handleIntegerChange(e.target.value, cfg.key, "last")
-											}
-										/>
-									</div>
-
-									<div className="flex items-center gap-3 ml-auto">
-										<span className="font-serif text-sm tracking-wider text-ink/80">
-											支数
-										</span>
-										<input
-											type="number"
-											aria-label={`${cfg.label} value`}
-											aria-invalid={!!error}
-											aria-describedby={error ? errorId : undefined}
-											className={inputClass}
-											value={state.value}
-											onChange={(e) => onValue(e.target.value)}
-										/>
-									</div>
+								<div className="flex items-center gap-3 ml-auto">
+									<span className="text-sm text-ink-soft">支数</span>
+									<input
+										type="number"
+										aria-label={`${cfg.label} value`}
+										aria-invalid={!!error}
+										aria-describedby={error ? errorId : undefined}
+										className={inputClass}
+										value={state.value}
+										onChange={(e) => onValue(e.target.value)}
+									/>
 								</div>
+							</div>
 
-								{error && (
-									<p
-										id={errorId}
-										role="alert"
-										data-testid={errorId}
-										className="mt-3 font-serif text-sm font-medium text-seal"
-									>
-										⚠ {error}
-									</p>
-								)}
-							</section>
-						);
-					})}
-				</div>
+							{error && (
+								<p
+									id={errorId}
+									role="alert"
+									data-testid={errorId}
+									className="mt-3 text-sm text-red-500"
+								>
+									{error}
+								</p>
+							)}
+						</section>
+					);
+				})}
 			</div>
 
-			<div className="flex justify-center gap-4 pt-8">
+			<div className="flex justify-center gap-3 pt-8">
 				<Button size="xl" type="button" onClick={handleSubmit}>
-					【 OK 确认 】
+					确认
 				</Button>
 				<Button
 					size="xl"
@@ -266,7 +256,7 @@ const CopyPage = () => {
 };
 
 const FallbackMessage = () => (
-	<div className="min-h-[60vh] flex items-center justify-center font-serif text-ink/70 text-lg">
+	<div className="min-h-[60vh] flex items-center justify-center text-ink-soft text-base">
 		没有该数据
 	</div>
 );

--- a/src/pages/CopyPage.tsx
+++ b/src/pages/CopyPage.tsx
@@ -62,7 +62,7 @@ type RangeState = { first: string; last: string; value: string };
 const emptyRange: RangeState = { first: "", last: "", value: "" };
 
 const inputClass =
-	"bg-white border border-gray-300 rounded-md px-2 py-1.5 w-[110px] tabular-nums focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400 transition-colors";
+	"bg-paper border border-rule rounded-sm px-3 py-2 w-[120px] font-serif tabular-nums text-center text-base focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 const CopyPage = () => {
 	const navigate = useNavigate();
@@ -75,8 +75,8 @@ const CopyPage = () => {
 	);
 	const [errors, setErrors] = useState<Record<string, string | null>>({});
 
-	if (!formConfig) return <>没有该数据</>;
-	if (!printData) return <>没有该数据</>;
+	if (!formConfig) return <FallbackMessage />;
+	if (!printData) return <FallbackMessage />;
 
 	const maxNum = formConfig.maxNum;
 
@@ -159,91 +159,116 @@ const CopyPage = () => {
 	};
 
 	return (
-		<div>
+		<div className="max-w-2xl mx-auto px-4 py-6">
 			<PageTitle summary={false} />
-			<div className="max-w-xl mx-auto">
-				<div className="rounded-lg border border-gray-200 bg-white shadow-sm p-6 space-y-5">
-					{RANGES.map((cfg, index) => {
+
+			<div className="border-2 border-double border-seal rounded-sm bg-paper shadow-sm">
+				<div className="border-b border-rule-soft px-6 py-3 text-center font-serif text-sm tracking-[0.3em] text-seal uppercase">
+					【 复制数据 / Copy Range 】
+				</div>
+
+				<div className="divide-y divide-rule-soft">
+					{RANGES.map((cfg) => {
 						const isDecimal = cfg.key === "pen";
 						const state = ranges[cfg.key];
 						const error = errors[cfg.key];
+						const errorId = `error-${cfg.key}`;
 						const onValue = (v: string) =>
 							isDecimal
 								? handleDecimalChange(v, cfg.key, "value")
 								: handleIntegerChange(v, cfg.key, "value");
 
 						return (
-							<div
-								key={cfg.key}
-								className={
-									index > 0 ? "pt-5 border-t border-gray-100" : undefined
-								}
-							>
-								<div className="flex items-center gap-3">
-									<span className="font-medium text-sm text-gray-700 w-[110px] text-right shrink-0">
+							<section key={cfg.key} className="px-6 py-5">
+								<div className="flex items-baseline justify-between mb-3">
+									<h3 className="font-serif text-base font-semibold tracking-[0.2em] text-seal uppercase">
 										{cfg.label}
+									</h3>
+									<span className="font-serif text-xs tracking-widest text-ink/60 uppercase">
+										Range
 									</span>
-									<input
-										type="number"
-										aria-label={`${cfg.label} first pile`}
-										aria-invalid={!!error}
-										className={inputClass}
-										value={state.first}
-										onChange={(e) =>
-											handleIntegerChange(e.target.value, cfg.key, "first")
-										}
-									/>
-									<span className="text-gray-400">—</span>
-									<input
-										type="number"
-										aria-label={`${cfg.label} last pile`}
-										aria-invalid={!!error}
-										className={inputClass}
-										value={state.last}
-										onChange={(e) =>
-											handleIntegerChange(e.target.value, cfg.key, "last")
-										}
-									/>
-									<span className="text-sm text-gray-600">支数=</span>
-									<input
-										type="number"
-										aria-label={`${cfg.label} value`}
-										aria-invalid={!!error}
-										className={inputClass}
-										value={state.value}
-										onChange={(e) => onValue(e.target.value)}
-									/>
 								</div>
+
+								<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+									<div className="flex items-center gap-2">
+										<input
+											type="number"
+											aria-label={`${cfg.label} first pile`}
+											aria-invalid={!!error}
+											aria-describedby={error ? errorId : undefined}
+											className={inputClass}
+											value={state.first}
+											onChange={(e) =>
+												handleIntegerChange(e.target.value, cfg.key, "first")
+											}
+										/>
+										<span className="text-rule font-serif text-xl">—</span>
+										<input
+											type="number"
+											aria-label={`${cfg.label} last pile`}
+											aria-invalid={!!error}
+											aria-describedby={error ? errorId : undefined}
+											className={inputClass}
+											value={state.last}
+											onChange={(e) =>
+												handleIntegerChange(e.target.value, cfg.key, "last")
+											}
+										/>
+									</div>
+
+									<div className="flex items-center gap-3 ml-auto">
+										<span className="font-serif text-sm tracking-wider text-ink/80">
+											支数
+										</span>
+										<input
+											type="number"
+											aria-label={`${cfg.label} value`}
+											aria-invalid={!!error}
+											aria-describedby={error ? errorId : undefined}
+											className={inputClass}
+											value={state.value}
+											onChange={(e) => onValue(e.target.value)}
+										/>
+									</div>
+								</div>
+
 								{error && (
 									<p
+										id={errorId}
 										role="alert"
-										data-testid={`error-${cfg.key}`}
-										className="mt-2 ml-[122px] text-sm font-medium text-red-600"
+										data-testid={errorId}
+										className="mt-3 font-serif text-sm font-medium text-seal"
 									>
 										⚠ {error}
 									</p>
 								)}
-							</div>
+							</section>
 						);
 					})}
 				</div>
+			</div>
 
-				<div className="flex justify-center gap-3 pt-6">
-					<Button size="xl" type="button" onClick={handleSubmit}>
-						OK 确认
-					</Button>
-					<Button
-						size="xl"
-						variant="ghost-outline"
-						type="button"
-						onClick={() => navigate("/newform")}
-					>
-						返回
-					</Button>
-				</div>
+			<div className="flex justify-center gap-4 pt-8">
+				<Button size="xl" type="button" onClick={handleSubmit}>
+					【 OK 确认 】
+				</Button>
+				<Button
+					size="xl"
+					variant="ghost-outline"
+					type="button"
+					onClick={() => navigate("/newform")}
+				>
+					返回
+				</Button>
 			</div>
 		</div>
 	);
 };
+
+const FallbackMessage = () => (
+	<div className="min-h-[60vh] flex items-center justify-center font-serif text-ink/70 text-lg">
+		没有该数据
+	</div>
+);
 
 export default CopyPage;

--- a/src/pages/CopyPage.tsx
+++ b/src/pages/CopyPage.tsx
@@ -62,7 +62,7 @@ type RangeState = { first: string; last: string; value: string };
 const emptyRange: RangeState = { first: "", last: "", value: "" };
 
 const inputClass =
-	"bg-surface border border-rule rounded-xl h-11 px-3 w-[110px] tabular-nums text-center focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+	"bg-paper border border-transparent rounded-lg h-9 px-2 w-[72px] text-base tabular-nums text-center focus:outline-none focus:bg-surface focus:border-seal focus:ring-2 focus:ring-seal/30 transition-colors";
 
 const CopyPage = () => {
 	const navigate = useNavigate();
@@ -159,7 +159,7 @@ const CopyPage = () => {
 	};
 
 	return (
-		<div className="max-w-2xl mx-auto px-4 py-6">
+		<div className="max-w-xl mx-auto px-4 py-10">
 			<PageTitle summary={false} />
 
 			<div className="bg-surface border border-rule rounded-2xl shadow-sm overflow-hidden">
@@ -176,14 +176,14 @@ const CopyPage = () => {
 					return (
 						<section
 							key={cfg.key}
-							className={`px-6 py-5 ${index > 0 ? "border-t border-rule-soft" : ""}`}
+							className={index > 0 ? "border-t border-rule-soft" : undefined}
 						>
-							<h3 className="text-sm font-semibold text-ink-soft tracking-wide mb-3">
-								{cfg.label}
-							</h3>
+							<div className="flex items-center gap-3 px-5 py-3 min-h-[56px]">
+								<span className="text-base font-medium text-ink flex-1 truncate">
+									{cfg.label}
+								</span>
 
-							<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
-								<div className="flex items-center gap-2">
+								<div className="flex items-center gap-1.5">
 									<input
 										type="number"
 										aria-label={`${cfg.label} first pile`}
@@ -195,7 +195,7 @@ const CopyPage = () => {
 											handleIntegerChange(e.target.value, cfg.key, "first")
 										}
 									/>
-									<span className="text-ink-soft">—</span>
+									<span className="text-ink-soft text-sm">—</span>
 									<input
 										type="number"
 										aria-label={`${cfg.label} last pile`}
@@ -209,7 +209,7 @@ const CopyPage = () => {
 									/>
 								</div>
 
-								<div className="flex items-center gap-3 ml-auto">
+								<div className="flex items-center gap-2 ml-3">
 									<span className="text-sm text-ink-soft">支数</span>
 									<input
 										type="number"
@@ -228,7 +228,7 @@ const CopyPage = () => {
 									id={errorId}
 									role="alert"
 									data-testid={errorId}
-									className="mt-3 text-sm text-red-500"
+									className="px-5 pb-3 -mt-1 text-sm text-red-500"
 								>
 									{error}
 								</p>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,6 +20,9 @@ import {
 import { clearPrintData, saveFormConfig } from "@/lib/storage";
 import formSchema, { type FormConfig } from "@/schemas/FormSchema";
 
+const inputClass =
+	"bg-paper border border-rule rounded-sm focus-visible:ring-seal focus-visible:border-seal";
+
 const HomePage = () => {
 	const navigate = useNavigate();
 
@@ -43,134 +46,147 @@ const HomePage = () => {
 		<Form {...form}>
 			<form
 				onSubmit={form.handleSubmit(onSubmit)}
-				className="flex flex-col items-center justify-center space-y-6 min-h-[calc(100vh-4rem)]"
+				className="flex flex-col items-center justify-center space-y-8 min-h-[calc(100vh-4rem)] px-4 py-10"
 			>
-				<div>
-					<div className="font-bold text-3xl text-gray-800">
+				<header className="text-center">
+					<div className="font-[var(--font-serif-cn)] text-4xl tracking-[0.4em] text-seal">
 						富財貿易打樁工程
 					</div>
-					<div className="font-bold text-2xl text-gray-700 mt-1">
-						FOOK CHOY TRADING & PILING ENGINEERING
+					<div className="mt-3 font-serif text-lg tracking-[0.2em] text-ink uppercase">
+						Fook Choy Trading &amp; Piling Engineering
 					</div>
-				</div>
+					<div className="mt-3 mx-auto h-px w-32 bg-seal" />
+				</header>
 
-				<div className="bg-blue-50 border border-blue-200 space-y-5 p-8 rounded-lg max-w-lg mx-auto">
-					<div className="text-sm font-medium text-gray-600">
-						输入需要的行数
+				<section className="bg-paper-strong/40 border-2 border-double border-seal rounded-sm shadow-sm max-w-lg w-full mx-auto">
+					<div className="border-b border-rule-soft px-6 py-3 text-center font-serif text-sm tracking-[0.3em] text-seal uppercase">
+						【 输入数据 / Input 】
 					</div>
-					<div className="flex justify-center gap-x-4 items-center">
-						<FormField
-							control={form.control}
-							name="minNum"
-							render={({ field }) => {
-								return (
-									<FormItem className="w-[180px]">
-										<FormControl>
-											<Input
-												className="bg-white rounded-md"
-												type="number"
-												placeholder="第一个号码"
-												{...field}
-												onChange={(e) => {
-													const val = e.target.value;
-													field.onChange(val === "" ? undefined : Number(val));
-												}}
-											/>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-						<div className="text-gray-400 font-bold">—</div>
-						<FormField
-							control={form.control}
-							name="maxNum"
-							render={({ field }) => {
-								return (
-									<FormItem className="w-[180px]">
-										<FormControl>
-											<Input
-												className="bg-white rounded-md"
-												type="number"
-												placeholder="最后的号码"
-												{...field}
-												onChange={(e) => {
-													const val = e.target.value;
-													field.onChange(val === "" ? undefined : Number(val));
-												}}
-											/>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-					</div>
-					<div className="w-[140px] mx-auto">
-						<FormField
-							control={form.control}
-							name="role"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<Select
-											onValueChange={field.onChange}
-											defaultValue={field.value}
-										>
+
+					<div className="space-y-6 px-8 py-7">
+						<div>
+							<div className="font-serif text-sm tracking-wider text-ink/80 mb-2 text-center">
+								号码范围 &nbsp;·&nbsp; Number range
+							</div>
+							<div className="flex justify-center gap-x-4 items-start">
+								<FormField
+									control={form.control}
+									name="minNum"
+									render={({ field }) => (
+										<FormItem className="w-[180px]">
 											<FormControl>
-												<SelectTrigger className="bg-white rounded-md">
-													<SelectValue placeholder="选择单位" />
-												</SelectTrigger>
+												<Input
+													className={inputClass}
+													type="number"
+													placeholder="第一个号码"
+													{...field}
+													onChange={(e) => {
+														const val = e.target.value;
+														field.onChange(
+															val === "" ? undefined : Number(val),
+														);
+													}}
+												/>
 											</FormControl>
-											<SelectContent>
-												<SelectItem value="meter">Meter</SelectItem>
-												<SelectItem value="foot">Foot</SelectItem>
-											</SelectContent>
-										</Select>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-					</div>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<div className="pt-2 text-rule font-serif text-xl">—</div>
+								<FormField
+									control={form.control}
+									name="maxNum"
+									render={({ field }) => (
+										<FormItem className="w-[180px]">
+											<FormControl>
+												<Input
+													className={inputClass}
+													type="number"
+													placeholder="最后的号码"
+													{...field}
+													onChange={(e) => {
+														const val = e.target.value;
+														field.onChange(
+															val === "" ? undefined : Number(val),
+														);
+													}}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+						</div>
 
-					<FormField
-						control={form.control}
-						name="showPileNo"
-						render={({ field }) => (
-							<FormItem>
-								<label className="flex items-center justify-between gap-3 rounded-md bg-white border border-blue-200 px-4 py-2.5 cursor-pointer hover:border-blue-300 transition-colors">
-									<span className="text-sm font-medium text-gray-700">
-										开启 PILE NO
-									</span>
-									<FormControl>
-										<button
-											type="button"
-											role="switch"
-											aria-checked={!!field.value}
-											onClick={() => field.onChange(!field.value)}
-											className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 ${
-												field.value ? "bg-blue-500" : "bg-gray-300"
-											}`}
-										>
-											<span
-												className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
-													field.value ? "translate-x-5" : "translate-x-0.5"
+						<div>
+							<div className="font-serif text-sm tracking-wider text-ink/80 mb-2 text-center">
+								单位 &nbsp;·&nbsp; Unit
+							</div>
+							<div className="w-[180px] mx-auto">
+								<FormField
+									control={form.control}
+									name="role"
+									render={({ field }) => (
+										<FormItem>
+											<Select
+												onValueChange={field.onChange}
+												defaultValue={field.value}
+											>
+												<FormControl>
+													<SelectTrigger className={inputClass}>
+														<SelectValue placeholder="选择单位" />
+													</SelectTrigger>
+												</FormControl>
+												<SelectContent>
+													<SelectItem value="meter">Meter / 米</SelectItem>
+													<SelectItem value="foot">Foot / 英尺</SelectItem>
+												</SelectContent>
+											</Select>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+						</div>
+
+						<FormField
+							control={form.control}
+							name="showPileNo"
+							render={({ field }) => (
+								<FormItem>
+									<label className="flex items-center justify-between gap-3 rounded-sm bg-paper border border-rule px-4 py-2.5 cursor-pointer hover:border-seal/60 transition-colors">
+										<span className="font-serif text-sm tracking-wider text-ink/80">
+											开启 PILE NO
+										</span>
+										<FormControl>
+											<button
+												type="button"
+												role="switch"
+												aria-checked={!!field.value}
+												onClick={() => field.onChange(!field.value)}
+												className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-seal ${
+													field.value ? "bg-seal" : "bg-rule"
 												}`}
-											/>
-										</button>
-									</FormControl>
-								</label>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
+											>
+												<span
+													className={`inline-block h-5 w-5 transform rounded-full bg-paper shadow transition-transform ${
+														field.value ? "translate-x-5" : "translate-x-0.5"
+													}`}
+												/>
+											</button>
+										</FormControl>
+									</label>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 
-					<Button type="submit" size="lg" className="w-full">
-						提交
-					</Button>
-				</div>
+						<Button type="submit" size="xl" className="w-full">
+							【 确认提交 】
+						</Button>
+					</div>
+				</section>
 			</form>
 		</Form>
 	);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -21,7 +21,7 @@ import { clearPrintData, saveFormConfig } from "@/lib/storage";
 import formSchema, { type FormConfig } from "@/schemas/FormSchema";
 
 const inputClass =
-	"bg-surface border border-rule rounded-sm focus-visible:ring-seal focus-visible:border-seal";
+	"bg-surface border border-rule rounded-xl h-11 focus-visible:ring-2 focus-visible:ring-seal focus-visible:ring-offset-0 focus-visible:border-seal";
 
 const HomePage = () => {
 	const navigate = useNavigate();
@@ -49,143 +49,128 @@ const HomePage = () => {
 				className="flex flex-col items-center justify-center space-y-8 min-h-[calc(100vh-4rem)] px-4 py-10"
 			>
 				<header className="text-center">
-					<div className="font-[var(--font-serif-cn)] text-4xl tracking-[0.4em] text-seal">
-						富財貿易打樁工程
-					</div>
-					<div className="mt-3 font-serif text-lg tracking-[0.2em] text-ink uppercase">
+					<h1 className="text-3xl font-semibold text-ink">富財貿易打樁工程</h1>
+					<p className="mt-2 text-sm font-medium text-ink-soft tracking-wide">
 						Fook Choy Trading &amp; Piling Engineering
-					</div>
-					<div className="mt-3 mx-auto h-px w-32 bg-seal" />
+					</p>
 				</header>
 
-				<section className="bg-surface border-2 border-double border-seal rounded-sm shadow-md max-w-lg w-full mx-auto">
-					<div className="border-b border-rule-soft px-6 py-3 text-center font-serif text-sm tracking-[0.3em] text-seal uppercase">
-						【 输入数据 / Input 】
+				<section className="bg-surface border border-rule rounded-2xl shadow-sm max-w-md w-full mx-auto p-7 space-y-6">
+					<div>
+						<div className="block text-sm font-medium text-ink-soft mb-2">
+							号码范围
+						</div>
+						<div className="flex items-center gap-3">
+							<FormField
+								control={form.control}
+								name="minNum"
+								render={({ field }) => (
+									<FormItem className="flex-1">
+										<FormControl>
+											<Input
+												className={inputClass}
+												type="number"
+												placeholder="起始"
+												{...field}
+												onChange={(e) => {
+													const val = e.target.value;
+													field.onChange(val === "" ? undefined : Number(val));
+												}}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<span className="text-ink-soft">—</span>
+							<FormField
+								control={form.control}
+								name="maxNum"
+								render={({ field }) => (
+									<FormItem className="flex-1">
+										<FormControl>
+											<Input
+												className={inputClass}
+												type="number"
+												placeholder="结束"
+												{...field}
+												onChange={(e) => {
+													const val = e.target.value;
+													field.onChange(val === "" ? undefined : Number(val));
+												}}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 					</div>
 
-					<div className="space-y-6 px-8 py-7">
-						<div>
-							<div className="font-serif text-sm tracking-wider text-ink/80 mb-2 text-center">
-								号码范围 &nbsp;·&nbsp; Number range
-							</div>
-							<div className="flex justify-center gap-x-4 items-start">
-								<FormField
-									control={form.control}
-									name="minNum"
-									render={({ field }) => (
-										<FormItem className="w-[180px]">
-											<FormControl>
-												<Input
-													className={inputClass}
-													type="number"
-													placeholder="第一个号码"
-													{...field}
-													onChange={(e) => {
-														const val = e.target.value;
-														field.onChange(
-															val === "" ? undefined : Number(val),
-														);
-													}}
-												/>
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-								<div className="pt-2 text-rule font-serif text-xl">—</div>
-								<FormField
-									control={form.control}
-									name="maxNum"
-									render={({ field }) => (
-										<FormItem className="w-[180px]">
-											<FormControl>
-												<Input
-													className={inputClass}
-													type="number"
-													placeholder="最后的号码"
-													{...field}
-													onChange={(e) => {
-														const val = e.target.value;
-														field.onChange(
-															val === "" ? undefined : Number(val),
-														);
-													}}
-												/>
-											</FormControl>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</div>
+					<div>
+						<div className="block text-sm font-medium text-ink-soft mb-2">
+							单位
 						</div>
-
-						<div>
-							<div className="font-serif text-sm tracking-wider text-ink/80 mb-2 text-center">
-								单位 &nbsp;·&nbsp; Unit
-							</div>
-							<div className="w-[180px] mx-auto">
-								<FormField
-									control={form.control}
-									name="role"
-									render={({ field }) => (
-										<FormItem>
-											<Select
-												onValueChange={field.onChange}
-												defaultValue={field.value}
-											>
-												<FormControl>
-													<SelectTrigger className={inputClass}>
-														<SelectValue placeholder="选择单位" />
-													</SelectTrigger>
-												</FormControl>
-												<SelectContent>
-													<SelectItem value="meter">Meter / 米</SelectItem>
-													<SelectItem value="foot">Foot / 英尺</SelectItem>
-												</SelectContent>
-											</Select>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</div>
-						</div>
-
 						<FormField
 							control={form.control}
-							name="showPileNo"
+							name="role"
 							render={({ field }) => (
 								<FormItem>
-									<label className="flex items-center justify-between gap-3 rounded-sm bg-paper-strong/50 border border-rule px-4 py-2.5 cursor-pointer hover:border-seal/60 transition-colors">
-										<span className="font-serif text-sm tracking-wider text-ink/80">
-											开启 PILE NO
-										</span>
+									<Select
+										onValueChange={field.onChange}
+										defaultValue={field.value}
+									>
 										<FormControl>
-											<button
-												type="button"
-												role="switch"
-												aria-checked={!!field.value}
-												onClick={() => field.onChange(!field.value)}
-												className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-seal ${
-													field.value ? "bg-seal" : "bg-rule"
-												}`}
-											>
-												<span
-													className={`inline-block h-5 w-5 transform rounded-full bg-surface shadow transition-transform ${
-														field.value ? "translate-x-5" : "translate-x-0.5"
-													}`}
-												/>
-											</button>
+											<SelectTrigger className={inputClass}>
+												<SelectValue placeholder="选择单位" />
+											</SelectTrigger>
 										</FormControl>
-									</label>
+										<SelectContent>
+											<SelectItem value="meter">Meter</SelectItem>
+											<SelectItem value="foot">Foot</SelectItem>
+										</SelectContent>
+									</Select>
 									<FormMessage />
 								</FormItem>
 							)}
 						/>
-
-						<Button type="submit" size="xl" className="w-full">
-							【 确认提交 】
-						</Button>
 					</div>
+
+					<FormField
+						control={form.control}
+						name="showPileNo"
+						render={({ field }) => (
+							<FormItem>
+								<label className="flex items-center justify-between gap-3 cursor-pointer">
+									<span className="text-sm font-medium text-ink">
+										开启 PILE NO
+									</span>
+									<FormControl>
+										<button
+											type="button"
+											role="switch"
+											aria-checked={!!field.value}
+											onClick={() => field.onChange(!field.value)}
+											className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-seal/40 ${
+												field.value ? "bg-seal" : "bg-rule"
+											}`}
+										>
+											<span
+												className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+													field.value ? "translate-x-5" : "translate-x-0.5"
+												}`}
+											/>
+										</button>
+									</FormControl>
+								</label>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					<Button type="submit" size="xl" className="w-full">
+						继续
+					</Button>
 				</section>
 			</form>
 		</Form>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -21,7 +21,7 @@ import { clearPrintData, saveFormConfig } from "@/lib/storage";
 import formSchema, { type FormConfig } from "@/schemas/FormSchema";
 
 const inputClass =
-	"bg-paper border border-rule rounded-sm focus-visible:ring-seal focus-visible:border-seal";
+	"bg-surface border border-rule rounded-sm focus-visible:ring-seal focus-visible:border-seal";
 
 const HomePage = () => {
 	const navigate = useNavigate();
@@ -58,7 +58,7 @@ const HomePage = () => {
 					<div className="mt-3 mx-auto h-px w-32 bg-seal" />
 				</header>
 
-				<section className="bg-paper-strong/40 border-2 border-double border-seal rounded-sm shadow-sm max-w-lg w-full mx-auto">
+				<section className="bg-surface border-2 border-double border-seal rounded-sm shadow-md max-w-lg w-full mx-auto">
 					<div className="border-b border-rule-soft px-6 py-3 text-center font-serif text-sm tracking-[0.3em] text-seal uppercase">
 						【 输入数据 / Input 】
 					</div>
@@ -155,7 +155,7 @@ const HomePage = () => {
 							name="showPileNo"
 							render={({ field }) => (
 								<FormItem>
-									<label className="flex items-center justify-between gap-3 rounded-sm bg-paper border border-rule px-4 py-2.5 cursor-pointer hover:border-seal/60 transition-colors">
+									<label className="flex items-center justify-between gap-3 rounded-sm bg-paper-strong/50 border border-rule px-4 py-2.5 cursor-pointer hover:border-seal/60 transition-colors">
 										<span className="font-serif text-sm tracking-wider text-ink/80">
 											开启 PILE NO
 										</span>
@@ -170,7 +170,7 @@ const HomePage = () => {
 												}`}
 											>
 												<span
-													className={`inline-block h-5 w-5 transform rounded-full bg-paper shadow transition-transform ${
+													className={`inline-block h-5 w-5 transform rounded-full bg-surface shadow transition-transform ${
 														field.value ? "translate-x-5" : "translate-x-0.5"
 													}`}
 												/>

--- a/src/pages/NewFormPage.tsx
+++ b/src/pages/NewFormPage.tsx
@@ -88,20 +88,20 @@ const NewFormPage = () => {
 	};
 
 	const inputClass =
-		"bg-surface border border-rule rounded-lg px-2 py-1.5 w-full tabular-nums focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+		"bg-surface border border-rule rounded-lg px-3 py-2.5 w-full text-base tabular-nums focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 	const metaInputClass =
-		"bg-surface border border-rule rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+		"bg-surface border border-rule rounded-lg px-3 py-2.5 text-base focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 	return (
-		<div className="max-w-4xl mx-auto px-4 py-6">
-			<form>
+		<div className="max-w-4xl mx-auto px-4 py-12 space-y-8">
+			<form className="space-y-8">
 				<PageTitle />
-				<div className="max-w-2xl mx-auto">
-					<div className="flex items-center justify-end gap-3 mb-3">
+				<div className="max-w-2xl mx-auto space-y-4">
+					<div className="flex items-center justify-end gap-3">
 						<label
 							htmlFor="meta-date"
-							className="text-sm font-medium text-ink-soft shrink-0"
+							className="text-base font-medium text-ink-soft shrink-0"
 						>
 							日期
 						</label>
@@ -115,11 +115,11 @@ const NewFormPage = () => {
 							onChange={(e) => setDate(e.target.value)}
 						/>
 					</div>
-					<div className="space-y-3">
+					<div className="space-y-4">
 						<div className="flex items-center gap-3">
 							<label
 								htmlFor="meta-project"
-								className="text-sm font-medium text-ink-soft w-[120px] text-right shrink-0"
+								className="text-base font-medium text-ink-soft w-[120px] text-right shrink-0"
 							>
 								Project
 							</label>
@@ -147,7 +147,7 @@ const NewFormPage = () => {
 						<div className="flex items-center gap-3">
 							<label
 								htmlFor="meta-pile"
-								className="text-sm font-medium text-ink-soft w-[120px] text-right shrink-0"
+								className="text-base font-medium text-ink-soft w-[120px] text-right shrink-0"
 							>
 								Size of pile
 							</label>
@@ -163,28 +163,28 @@ const NewFormPage = () => {
 					</div>
 				</div>
 
-				<div className="mt-6 bg-surface border border-rule rounded-2xl shadow-sm overflow-hidden">
+				<div className="bg-surface border border-rule rounded-2xl shadow-sm overflow-hidden">
 					<table className="border-collapse mx-auto w-full">
 						<thead>
 							<tr className="bg-paper-strong">
-								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+								<th className="text-sm font-semibold text-ink uppercase tracking-wide px-3 py-4">
 									NO.
 								</th>
 								{showPileNo && (
-									<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+									<th className="text-sm font-semibold text-ink uppercase tracking-wide px-3 py-4">
 										PILE NO
 									</th>
 								)}
-								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+								<th className="text-sm font-semibold text-ink uppercase tracking-wide px-3 py-4">
 									PILE LENGTHS 6 METER
 								</th>
-								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+								<th className="text-sm font-semibold text-ink uppercase tracking-wide px-3 py-4">
 									PILE LENGTHS 3 METER
 								</th>
-								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+								<th className="text-sm font-semibold text-ink uppercase tracking-wide px-3 py-4">
 									JOINTS NO
 								</th>
-								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+								<th className="text-sm font-semibold text-ink uppercase tracking-wide px-3 py-4">
 									{formConfig.role}
 								</th>
 							</tr>
@@ -195,7 +195,7 @@ const NewFormPage = () => {
 									key={`row-${formConfig.minNum + rowIndex}`}
 									className="border-t border-rule-soft"
 								>
-									<td className="text-sm text-center font-medium text-ink-soft px-2 tabular-nums">
+									<td className="text-base text-center font-medium text-ink-soft px-3 py-1.5 tabular-nums">
 										{formConfig.minNum + rowIndex}
 									</td>
 									{showPileNo && (

--- a/src/pages/NewFormPage.tsx
+++ b/src/pages/NewFormPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import PageTitle from "@/components/PageTitle";
+import { Button } from "@/components/ui/Button";
 import { ROW_COL, ROW_LENGTH } from "@/lib/columns";
 import { sanitizeDecimal, sanitizeInteger } from "@/lib/sanitize";
 import { loadFormConfig, loadPrintData, savePrintData } from "@/lib/storage";
@@ -28,7 +29,12 @@ const NewFormPage = () => {
 	const [pile, setPile] = useState(existingPrintData?.pile ?? "");
 	const [date, setDate] = useState(existingPrintData?.date ?? "");
 
-	if (!formConfig) return <div>没有该数据</div>;
+	if (!formConfig)
+		return (
+			<div className="min-h-[60vh] flex items-center justify-center font-serif text-ink/70 text-lg">
+				没有该数据
+			</div>
+		);
 	const showPileNo = !!formConfig.showPileNo;
 
 	const updateCell = (rowIndex: number, colIndex: number, next: string) => {
@@ -82,36 +88,39 @@ const NewFormPage = () => {
 	};
 
 	const inputClass =
-		"bg-white border border-gray-300 rounded px-2 py-1 w-full focus:outline-none focus:ring-2 focus:ring-blue-300";
+		"bg-paper border border-rule rounded-sm px-2 py-1 w-full font-serif tabular-nums focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+
+	const metaInputClass =
+		"bg-paper border border-rule rounded-sm px-3 py-1.5 font-serif focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 	return (
-		<div>
+		<div className="max-w-4xl mx-auto px-4 py-6">
 			<form>
 				<PageTitle />
 				<div className="max-w-2xl mx-auto">
 					<div className="flex items-center justify-end gap-3 mb-3">
-						<span className="font-bold text-sm text-gray-700 shrink-0">
-							DATE:
+						<span className="font-serif text-sm font-semibold tracking-wider text-seal shrink-0">
+							DATE
 						</span>
 						<input
 							type="text"
 							maxLength={10}
 							placeholder="DD/MM/YYYY"
-							className="bg-white border border-gray-300 rounded-md px-3 py-1.5 w-[150px] focus:outline-none focus:ring-2 focus:ring-blue-300"
+							className={`${metaInputClass} w-[150px]`}
 							value={date}
 							onChange={(e) => setDate(e.target.value)}
 						/>
 					</div>
 					<div className="space-y-3">
 						<div className="flex items-center gap-3">
-							<span className="font-bold text-sm text-gray-700 w-[120px] text-right shrink-0">
-								PROJECT:
+							<span className="font-serif text-sm font-semibold tracking-wider text-seal w-[120px] text-right shrink-0">
+								PROJECT
 							</span>
 							<input
 								type="text"
 								maxLength={100}
 								name="p1"
-								className="bg-white border border-gray-300 rounded-md px-3 py-1.5 flex-1 focus:outline-none focus:ring-2 focus:ring-blue-300"
+								className={`${metaInputClass} flex-1`}
 								value={project}
 								onChange={(e) => setProject(e.target.value)}
 							/>
@@ -121,19 +130,19 @@ const NewFormPage = () => {
 							<input
 								type="text"
 								maxLength={100}
-								className="bg-white border border-gray-300 rounded-md px-3 py-1.5 flex-1 focus:outline-none focus:ring-2 focus:ring-blue-300"
+								className={`${metaInputClass} flex-1`}
 								value={project2}
 								onChange={(e) => setProject2(e.target.value)}
 							/>
 						</div>
 						<div className="flex items-center gap-3">
-							<span className="font-bold text-sm text-gray-700 w-[120px] text-right shrink-0">
-								SIZE OF PILE:
+							<span className="font-serif text-sm font-semibold tracking-wider text-seal w-[120px] text-right shrink-0">
+								SIZE OF PILE
 							</span>
 							<input
 								type="text"
 								maxLength={100}
-								className="bg-white border border-gray-300 rounded-md px-3 py-1.5 flex-1 focus:outline-none focus:ring-2 focus:ring-blue-300"
+								className={`${metaInputClass} flex-1`}
 								value={pile}
 								onChange={(e) => setPile(e.target.value)}
 							/>
@@ -141,21 +150,27 @@ const NewFormPage = () => {
 					</div>
 				</div>
 
-				<table className="border-collapse mx-auto mt-5">
+				<table className="border-collapse mx-auto mt-5 font-serif">
 					<thead>
-						<tr className="bg-gray-100">
-							<th className="text-sm font-semibold text-gray-700">NO.</th>
+						<tr className="bg-paper-strong border-y-2 border-double border-seal">
+							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
+								NO.
+							</th>
 							{showPileNo && (
-								<th className="text-sm font-semibold text-gray-700">PILE NO</th>
+								<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
+									PILE NO
+								</th>
 							)}
-							<th className="text-sm font-semibold text-gray-700">
+							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
 								PILE LENGTHS 6 METER
 							</th>
-							<th className="text-sm font-semibold text-gray-700">
+							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
 								PILE LENGTHS 3 METER
 							</th>
-							<th className="text-sm font-semibold text-gray-700">JOINTS NO</th>
-							<th className="text-sm font-semibold text-gray-700 uppercase">
+							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
+								JOINTS NO
+							</th>
+							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
 								{formConfig.role}
 							</th>
 						</tr>
@@ -164,9 +179,9 @@ const NewFormPage = () => {
 						{values.map((row, rowIndex) => (
 							<tr
 								key={`row-${formConfig.minNum + rowIndex}`}
-								className="even:bg-gray-50"
+								className="even:bg-paper-strong/30"
 							>
-								<td className="text-sm text-center font-medium text-gray-700 px-2">
+								<td className="text-sm text-center font-semibold text-ink px-2 tabular-nums">
 									{formConfig.minNum + rowIndex}
 								</td>
 								{showPileNo && (
@@ -257,21 +272,13 @@ const NewFormPage = () => {
 					</tbody>
 				</table>
 
-				<div className="flex justify-center gap-3 pt-5">
-					<button
-						className="bg-amber-400 hover:bg-amber-500 text-gray-800 font-medium px-8 py-2 rounded-md cursor-pointer transition-colors"
-						type="button"
-						onClick={handleSave}
-					>
-						保存
-					</button>
-					<button
-						className="bg-amber-400 hover:bg-amber-500 text-gray-800 font-medium px-8 py-2 rounded-md cursor-pointer transition-colors"
-						type="button"
-						onClick={handleCopy}
-					>
+				<div className="flex justify-center gap-4 pt-8">
+					<Button size="xl" type="button" onClick={handleSave}>
+						【 保存打印 】
+					</Button>
+					<Button size="xl" variant="seal" type="button" onClick={handleCopy}>
 						复制
-					</button>
+					</Button>
 				</div>
 			</form>
 		</div>

--- a/src/pages/NewFormPage.tsx
+++ b/src/pages/NewFormPage.tsx
@@ -88,10 +88,10 @@ const NewFormPage = () => {
 	};
 
 	const inputClass =
-		"bg-paper border border-rule rounded-sm px-2 py-1 w-full font-serif tabular-nums focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+		"bg-surface border border-rule rounded-sm px-2 py-1 w-full font-serif tabular-nums focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 	const metaInputClass =
-		"bg-paper border border-rule rounded-sm px-3 py-1.5 font-serif focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+		"bg-surface border border-rule rounded-sm px-3 py-1.5 font-serif focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 	return (
 		<div className="max-w-4xl mx-auto px-4 py-6">

--- a/src/pages/NewFormPage.tsx
+++ b/src/pages/NewFormPage.tsx
@@ -88,10 +88,10 @@ const NewFormPage = () => {
 	};
 
 	const inputClass =
-		"bg-surface border border-rule rounded-sm px-2 py-1 w-full font-serif tabular-nums focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+		"bg-surface border border-rule rounded-lg px-2 py-1.5 w-full tabular-nums focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 	const metaInputClass =
-		"bg-surface border border-rule rounded-sm px-3 py-1.5 font-serif focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
+		"bg-surface border border-rule rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-seal focus:border-seal transition-colors";
 
 	return (
 		<div className="max-w-4xl mx-auto px-4 py-6">
@@ -99,24 +99,32 @@ const NewFormPage = () => {
 				<PageTitle />
 				<div className="max-w-2xl mx-auto">
 					<div className="flex items-center justify-end gap-3 mb-3">
-						<span className="font-serif text-sm font-semibold tracking-wider text-seal shrink-0">
-							DATE
-						</span>
+						<label
+							htmlFor="meta-date"
+							className="text-sm font-medium text-ink-soft shrink-0"
+						>
+							日期
+						</label>
 						<input
+							id="meta-date"
 							type="text"
 							maxLength={10}
 							placeholder="DD/MM/YYYY"
-							className={`${metaInputClass} w-[150px]`}
+							className={`${metaInputClass} w-[160px]`}
 							value={date}
 							onChange={(e) => setDate(e.target.value)}
 						/>
 					</div>
 					<div className="space-y-3">
 						<div className="flex items-center gap-3">
-							<span className="font-serif text-sm font-semibold tracking-wider text-seal w-[120px] text-right shrink-0">
-								PROJECT
-							</span>
+							<label
+								htmlFor="meta-project"
+								className="text-sm font-medium text-ink-soft w-[120px] text-right shrink-0"
+							>
+								Project
+							</label>
 							<input
+								id="meta-project"
 								type="text"
 								maxLength={100}
 								name="p1"
@@ -130,16 +138,21 @@ const NewFormPage = () => {
 							<input
 								type="text"
 								maxLength={100}
+								aria-label="Project (line 2)"
 								className={`${metaInputClass} flex-1`}
 								value={project2}
 								onChange={(e) => setProject2(e.target.value)}
 							/>
 						</div>
 						<div className="flex items-center gap-3">
-							<span className="font-serif text-sm font-semibold tracking-wider text-seal w-[120px] text-right shrink-0">
-								SIZE OF PILE
-							</span>
+							<label
+								htmlFor="meta-pile"
+								className="text-sm font-medium text-ink-soft w-[120px] text-right shrink-0"
+							>
+								Size of pile
+							</label>
 							<input
+								id="meta-pile"
 								type="text"
 								maxLength={100}
 								className={`${metaInputClass} flex-1`}
@@ -150,133 +163,140 @@ const NewFormPage = () => {
 					</div>
 				</div>
 
-				<table className="border-collapse mx-auto mt-5 font-serif">
-					<thead>
-						<tr className="bg-paper-strong border-y-2 border-double border-seal">
-							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
-								NO.
-							</th>
-							{showPileNo && (
-								<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
-									PILE NO
+				<div className="mt-6 bg-surface border border-rule rounded-2xl shadow-sm overflow-hidden">
+					<table className="border-collapse mx-auto w-full">
+						<thead>
+							<tr className="bg-paper-strong">
+								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+									NO.
 								</th>
-							)}
-							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
-								PILE LENGTHS 6 METER
-							</th>
-							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
-								PILE LENGTHS 3 METER
-							</th>
-							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
-								JOINTS NO
-							</th>
-							<th className="text-xs font-semibold tracking-wider text-seal uppercase px-2">
-								{formConfig.role}
-							</th>
-						</tr>
-					</thead>
-					<tbody>
-						{values.map((row, rowIndex) => (
-							<tr
-								key={`row-${formConfig.minNum + rowIndex}`}
-								className="even:bg-paper-strong/30"
-							>
-								<td className="text-sm text-center font-semibold text-ink px-2 tabular-nums">
-									{formConfig.minNum + rowIndex}
-								</td>
 								{showPileNo && (
+									<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+										PILE NO
+									</th>
+								)}
+								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+									PILE LENGTHS 6 METER
+								</th>
+								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+									PILE LENGTHS 3 METER
+								</th>
+								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+									JOINTS NO
+								</th>
+								<th className="text-xs font-semibold text-ink uppercase tracking-wide px-3 py-3">
+									{formConfig.role}
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{values.map((row, rowIndex) => (
+								<tr
+									key={`row-${formConfig.minNum + rowIndex}`}
+									className="border-t border-rule-soft"
+								>
+									<td className="text-sm text-center font-medium text-ink-soft px-2 tabular-nums">
+										{formConfig.minNum + rowIndex}
+									</td>
+									{showPileNo && (
+										<td>
+											<input
+												type="number"
+												autoComplete="off"
+												aria-label={`Row ${rowIndex + 1} pile number`}
+												className={inputClass}
+												value={row[ROW_COL.PILE_NO]}
+												onChange={(e) =>
+													handleIntegerChange(
+														e.target.value,
+														rowIndex,
+														ROW_COL.PILE_NO,
+													)
+												}
+											/>
+										</td>
+									)}
 									<td>
 										<input
 											type="number"
 											autoComplete="off"
-											aria-label={`Row ${rowIndex + 1} pile number`}
+											aria-label={`Row ${rowIndex + 1} 6-meter count`}
 											className={inputClass}
-											value={row[ROW_COL.PILE_NO]}
+											value={row[ROW_COL.SIX_M]}
 											onChange={(e) =>
 												handleIntegerChange(
 													e.target.value,
 													rowIndex,
-													ROW_COL.PILE_NO,
+													ROW_COL.SIX_M,
 												)
 											}
 										/>
 									</td>
-								)}
-								<td>
-									<input
-										type="number"
-										autoComplete="off"
-										aria-label={`Row ${rowIndex + 1} 6-meter count`}
-										className={inputClass}
-										value={row[ROW_COL.SIX_M]}
-										onChange={(e) =>
-											handleIntegerChange(
-												e.target.value,
-												rowIndex,
-												ROW_COL.SIX_M,
-											)
-										}
-									/>
-								</td>
-								<td>
-									<input
-										type="number"
-										autoComplete="off"
-										aria-label={`Row ${rowIndex + 1} 3-meter count`}
-										className={inputClass}
-										value={row[ROW_COL.THREE_M]}
-										onChange={(e) =>
-											handleIntegerChange(
-												e.target.value,
-												rowIndex,
-												ROW_COL.THREE_M,
-											)
-										}
-									/>
-								</td>
-								<td>
-									<input
-										type="number"
-										autoComplete="off"
-										aria-label={`Row ${rowIndex + 1} joints count`}
-										className={inputClass}
-										value={row[ROW_COL.JOINTS]}
-										onChange={(e) =>
-											handleIntegerChange(
-												e.target.value,
-												rowIndex,
-												ROW_COL.JOINTS,
-											)
-										}
-									/>
-								</td>
-								<td>
-									<input
-										type="number"
-										autoComplete="off"
-										aria-label={`Row ${rowIndex + 1} penetration`}
-										pattern="^\d+(?:\.\d{1,2})?$"
-										className={inputClass}
-										value={row[ROW_COL.PENETRATION]}
-										onChange={(e) =>
-											handleDecimalChange(
-												e.target.value,
-												rowIndex,
-												ROW_COL.PENETRATION,
-											)
-										}
-									/>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
+									<td>
+										<input
+											type="number"
+											autoComplete="off"
+											aria-label={`Row ${rowIndex + 1} 3-meter count`}
+											className={inputClass}
+											value={row[ROW_COL.THREE_M]}
+											onChange={(e) =>
+												handleIntegerChange(
+													e.target.value,
+													rowIndex,
+													ROW_COL.THREE_M,
+												)
+											}
+										/>
+									</td>
+									<td>
+										<input
+											type="number"
+											autoComplete="off"
+											aria-label={`Row ${rowIndex + 1} joints count`}
+											className={inputClass}
+											value={row[ROW_COL.JOINTS]}
+											onChange={(e) =>
+												handleIntegerChange(
+													e.target.value,
+													rowIndex,
+													ROW_COL.JOINTS,
+												)
+											}
+										/>
+									</td>
+									<td>
+										<input
+											type="number"
+											autoComplete="off"
+											aria-label={`Row ${rowIndex + 1} penetration`}
+											pattern="^\d+(?:\.\d{1,2})?$"
+											className={inputClass}
+											value={row[ROW_COL.PENETRATION]}
+											onChange={(e) =>
+												handleDecimalChange(
+													e.target.value,
+													rowIndex,
+													ROW_COL.PENETRATION,
+												)
+											}
+										/>
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
 
-				<div className="flex justify-center gap-4 pt-8">
+				<div className="flex justify-center gap-3 pt-8">
 					<Button size="xl" type="button" onClick={handleSave}>
-						【 保存打印 】
+						保存
 					</Button>
-					<Button size="xl" variant="seal" type="button" onClick={handleCopy}>
+					<Button
+						size="xl"
+						variant="ghost-outline"
+						type="button"
+						onClick={handleCopy}
+					>
 						复制
 					</Button>
 				</div>

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import "./printpage.css";
 import PageTitle from "@/components/PageTitle";
+import { Button } from "@/components/ui/Button";
 import { PRINT_COL } from "@/lib/columns";
 import { loadFormConfig, loadPrintData } from "@/lib/storage";
 
@@ -132,23 +133,24 @@ const PrintPage = () => {
 				</tbody>
 			</table>
 
-			<div className="flex justify-center gap-3 mb-10">
-				<button
+			<div className="flex justify-center gap-3 mb-10 print:hidden">
+				<Button
+					size="xl"
 					type="button"
 					id="p"
 					onClick={() => window.print()}
-					className="bg-amber-400 hover:bg-amber-500 text-gray-800 font-medium px-8 py-2 rounded-md cursor-pointer transition-colors"
 				>
-					Print
-				</button>
-				<button
+					打印
+				</Button>
+				<Button
+					size="xl"
+					variant="ghost-outline"
 					type="button"
 					id="e"
 					onClick={() => navigate("/newform")}
-					className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-medium px-8 py-2 rounded-md cursor-pointer transition-colors"
 				>
 					修改
-				</button>
+				</Button>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary

Full visual overhaul to a minimal Apple-style design across HomePage, CopyPage, NewFormPage, and PrintPage actions. PrintPage output untouched.

### Theme (`src/index.css`)
- Repaints `@theme` tokens: `paper #f5f5f7`, `surface #fff`, `ink #1d1d1f`, `ink-soft #6e6e73`, `seal #1d1d1f` (primary = ink-black), `rule #d2d2d7`.
- Body font swapped to system stack (`-apple-system`, `SF Pro Text`, `PingFang SC`).

### Button
- Pill (`rounded-full`), `bg-seal` (ink) + `text-white`, `active:scale-[0.98]` for iOS press tick.
- `ghost-outline` variant: surface bg + rule border.
- `xl` size for primary CTAs.

### Pages
- **HomePage** — single white card on paper bg; pill inputs; toggle switch in ink; group labels become `<div>` (a11y compliant).
- **CopyPage** — sections in one rounded-2xl card with `rule-soft` dividers; iOS Settings-style single-row layout (label flush-left, controls flush-right); paper-bg inputs flip to surface + seal ring on focus; inline error with `aria-describedby`; CTAs 确认 / 返回.
- **NewFormPage** — meta inputs with proper `htmlFor`; table in bordered card with `paper-strong` header band; restored full "PILE LENGTHS …" header text; padding `py-12`, header `py-4` `text-sm`, cells `text-base` for older eyes; Save (default) / Copy (ghost-outline).
- **PrintPage** — only action buttons swapped to `<Button>` (`print:hidden`) so the printed sheet is unchanged; 打印 / 修改.
- **PageTitle** — flat sans header, no brackets, no double rules.

### Tests
- `Button.test.tsx` color assertions repointed at `bg-seal` + `text-white`, added `rounded-full` check.
- `CopyPage.test.tsx` button query updated to "确认".
- 51/51 pass.

## Commit-by-commit
- `6aaa168` — first letterhead theme (crimson serif)
- `a80bb05` — palette swap to 茶色 tea-brown
- `93f4f19` — surface token to lift cards off the cream bg
- `e26b376` — Apple monochrome reset (current direction)
- `1d6a21f` — NewFormPage padding + font polish
- `6b1083b` — CopyPage iOS Settings-style rows + tighter gaps

History intentionally shows the design exploration; squash on merge if you prefer a single landing commit.

## Test plan
- [x] `yarn test` — 51/51
- [x] `yarn build` — tsc + vite build clean
- [ ] Manual: load /, /newform, /copy, /print — confirm typography, focus rings, button colors
- [ ] Print preview on /print — verify buttons hidden, content unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)